### PR TITLE
docs: add 1.3.6 shop changelog entries

### DIFF
--- a/public/addons/shop/changelog/index.html
+++ b/public/addons/shop/changelog/index.html
@@ -317,6 +317,18 @@
   <h1>Changelog</h1>
 
   <p>All notable changes to Perch Shop.</p>
+<h2 id="-1-3-6-yyyy-mm-dd">[1.3.6] - YYYY-MM-DD</h2>
+<h3 id="fixed">Fixed</h3>
+<ul>
+<li>VAT-inclusive price calculation.</li>
+<li>PDF invoice generation issues.</li>
+<li>Shipping methods now allowed without category restrictions.</li>
+</ul>
+<h3 id="added">Added</h3>
+<ul>
+<li>Category validation in <code>find_options_for_cart</code>.</li>
+<li>Product list reordering feature.</li>
+</ul>
 <h2 id="-1-3-5-2025-01-14">[1.3.5] - 2025-01-14</h2>
 <h3 id="fixed">Fixed</h3>
 <ul>

--- a/src/addons/shop/changelog.md
+++ b/src/addons/shop/changelog.md
@@ -5,6 +5,16 @@ nav_groups:
 ---
 
 All notable changes to Perch Shop.
+## [1.3.6] - YYYY-MM-DD
+### Fixed
+- VAT-inclusive price calculation.
+- PDF invoice generation issues.
+- Shipping methods now allowed without category restrictions.
+
+### Added
+- Category validation in `find_options_for_cart`.
+- Product list reordering feature.
+
 ## [1.3.5] - 2025-01-14
 ### Fixed
 - Fixes for PHP 8.2 compatibility


### PR DESCRIPTION
## Summary
- document shop 1.3.6 release with fixes for VAT-inclusive pricing, PDF invoices, and shipping method category restrictions
- note added category validation for `find_options_for_cart` and product list reordering feature

## Testing
- `node build.js` *(fails: Cannot find module './plugins/indexer/index.js')*


------
https://chatgpt.com/codex/tasks/task_b_68c430176ff4832497bd19719c7bda49